### PR TITLE
feat: Rollback for plugins

### DIFF
--- a/samples/BoyInTheAudiencePlugin/BoyInTheAudiencePlugin.csproj
+++ b/samples/BoyInTheAudiencePlugin/BoyInTheAudiencePlugin.csproj
@@ -8,9 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Looplex.OpenForExtension" Version="1.1.8">
-	    <ExcludeAssets>runtime</ExcludeAssets>
-    </PackageReference>
+    <ProjectReference Include="..\..\src\Looplex.OpenForExtension\Looplex.OpenForExtension.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/BoyInTheAudiencePlugin/Commands/BindCommand.cs
+++ b/samples/BoyInTheAudiencePlugin/Commands/BindCommand.cs
@@ -44,5 +44,10 @@ namespace BoyInTheAudiencePlugin.Commands
                 }
             }
         }
+
+        public Task ExecuteRollBackAsync(IContext context)
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/samples/BoyInTheAudiencePlugin/Commands/DefineActorsCommand.cs
+++ b/samples/BoyInTheAudiencePlugin/Commands/DefineActorsCommand.cs
@@ -24,5 +24,10 @@ namespace BoyInTheAudiencePlugin.Commands
             
             return Task.CompletedTask;
         }
+
+        public Task ExecuteRollBackAsync(IContext context)
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/samples/MutantNinjaTurtlePlugin/Commands/DefineActorsCommand.cs
+++ b/samples/MutantNinjaTurtlePlugin/Commands/DefineActorsCommand.cs
@@ -28,5 +28,10 @@ namespace MutantNinjaTurtlePlugin.Commands
 
             return Task.CompletedTask;
         }
+
+        public Task ExecuteRollBackAsync(IContext context)
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/samples/MutantNinjaTurtlePlugin/MutantNinjaTurtlePlugin.csproj
+++ b/samples/MutantNinjaTurtlePlugin/MutantNinjaTurtlePlugin.csproj
@@ -8,12 +8,7 @@
   </PropertyGroup>
 	
   <ItemGroup>
-    <PackageReference Include="Looplex.OpenForExtension" Version="1.1.8">
-	    <ExcludeAssets>runtime</ExcludeAssets>
-    </PackageReference>
-  </ItemGroup>
-	
-  <ItemGroup>
+	<ProjectReference Include="..\..\src\Looplex.OpenForExtension\Looplex.OpenForExtension.csproj" />
 	<ProjectReference Include="..\TheTortoiseAndTheHareAppSample.Domain\TheTortoiseAndTheHareAppSample.Domain.csproj">
 	  <ExcludeAssets>runtime</ExcludeAssets>
 	</ProjectReference>

--- a/samples/TheTortoiseAndTheHareAppSample.Domain/TheTortoiseAndTheHareAppSample.Domain.csproj
+++ b/samples/TheTortoiseAndTheHareAppSample.Domain/TheTortoiseAndTheHareAppSample.Domain.csproj
@@ -5,9 +5,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-	
+
   <ItemGroup>
-	<PackageReference Include="Looplex.OpenForExtension" Version="1.1.8" />
+    <ProjectReference Include="..\..\src\Looplex.OpenForExtension\Looplex.OpenForExtension.csproj" />
   </ItemGroup>
 	
 </Project>

--- a/samples/TheTortoiseAndTheHareAppSample/TheTortoiseAndTheHareAppSample.csproj
+++ b/samples/TheTortoiseAndTheHareAppSample/TheTortoiseAndTheHareAppSample.csproj
@@ -9,11 +9,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.2" />
-	<PackageReference Include="Looplex.OpenForExtension" Version="1.1.8" />
-    <PackageReference Include="Looplex.OpenForExtension.Loader" Version="1.1.8" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Looplex.OpenForExtension.Loader\Looplex.OpenForExtension.Loader.csproj" />
+    <ProjectReference Include="..\..\src\Looplex.OpenForExtension\Looplex.OpenForExtension.csproj" />
     <ProjectReference Include="..\TheTortoiseAndTheHareAppSample.Domain\TheTortoiseAndTheHareAppSample.Domain.csproj" />
   </ItemGroup>
 

--- a/src/Looplex.OpenForExtension.Abstractions/Commands/ICommand.cs
+++ b/src/Looplex.OpenForExtension.Abstractions/Commands/ICommand.cs
@@ -7,5 +7,6 @@ namespace Looplex.OpenForExtension.Abstractions.Commands
     public interface ICommand
     {
         Task ExecuteAsync(IContext context, CancellationToken cancellationToken);
+        Task ExecuteRollBackAsync(IContext context);
     }
 }

--- a/src/Looplex.OpenForExtension.Abstractions/Contexts/IContext.cs
+++ b/src/Looplex.OpenForExtension.Abstractions/Contexts/IContext.cs
@@ -12,9 +12,9 @@ namespace Looplex.OpenForExtension.Abstractions.Contexts
         dynamic State { get; }
         IDictionary<string, dynamic> Roles { get; }
         object Result { get; set; }
-        Stack<Func<Task>> RollBackActions { get; }
+        Stack<NamedRollBack> RollBackActions { get; }
 
         Task DoRollBack(Func<IContext, Task> logAction = null);
-        void AddRollBackAction(Func<Task> rollBackAction);
+        void AddRollBackAction(Func<Task> rollBackAction, string pluginName);
     }
 }

--- a/src/Looplex.OpenForExtension.Abstractions/Contexts/IContext.cs
+++ b/src/Looplex.OpenForExtension.Abstractions/Contexts/IContext.cs
@@ -12,7 +12,7 @@ namespace Looplex.OpenForExtension.Abstractions.Contexts
         dynamic State { get; }
         IDictionary<string, dynamic> Roles { get; }
         object Result { get; set; }
-        Stack<Func<Task>> RollBackActions { get; set; }
+        Stack<Func<Task>> RollBackActions { get; }
 
         Task DoRollBack(Func<IContext, Task> logAction = null);
         void AddRollBackAction(Func<Task> rollBackAction);

--- a/src/Looplex.OpenForExtension.Abstractions/Contexts/IContext.cs
+++ b/src/Looplex.OpenForExtension.Abstractions/Contexts/IContext.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
-using Looplex.OpenForExtension.Abstractions.Plugins;
+﻿using Looplex.OpenForExtension.Abstractions.Plugins;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Looplex.OpenForExtension.Abstractions.Contexts
 {
@@ -10,5 +12,9 @@ namespace Looplex.OpenForExtension.Abstractions.Contexts
         dynamic State { get; }
         IDictionary<string, dynamic> Roles { get; }
         object Result { get; set; }
+        Stack<Func<Task>> RollBackActions { get; set; }
+
+        Task DoRollBack(Func<IContext, Task> logAction = null);
+        void AddRollBackAction(Func<Task> rollBackAction);
     }
 }

--- a/src/Looplex.OpenForExtension.Abstractions/NamedRollBack.cs
+++ b/src/Looplex.OpenForExtension.Abstractions/NamedRollBack.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Looplex.OpenForExtension.Abstractions
+{
+    public class NamedRollBack
+    {
+        public string Name { get; set; }
+        public Func<Task> Action { get; set; }
+    }
+}

--- a/src/Looplex.OpenForExtension.Loader/Looplex.OpenForExtension.Loader.csproj
+++ b/src/Looplex.OpenForExtension.Loader/Looplex.OpenForExtension.Loader.csproj
@@ -20,15 +20,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="\"/>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Runtime.Loader" Version="4.3.0"/>
+    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Looplex.OpenForExtension\Looplex.OpenForExtension.csproj"/>
+    <ProjectReference Include="..\Looplex.OpenForExtension\Looplex.OpenForExtension.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Looplex.OpenForExtension.Loader/PluginLoadContext.cs
+++ b/src/Looplex.OpenForExtension.Loader/PluginLoadContext.cs
@@ -15,6 +15,10 @@ namespace Looplex.OpenForExtension.Loader
         protected override Assembly? Load(AssemblyName assemblyName)
         {
             string? assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
+            if (assemblyName.Name == "Looplex.OpenForExtension.Abstractions")
+            {
+                return null;
+            }
             if (assemblyPath != null)
             {
                 return LoadFromAssemblyPath(assemblyPath);

--- a/src/Looplex.OpenForExtension/Contexts/DefaultContext.cs
+++ b/src/Looplex.OpenForExtension/Contexts/DefaultContext.cs
@@ -17,7 +17,8 @@ namespace Looplex.OpenForExtension.Contexts
         public Stack<Func<Task>> RollBackActions { get; } = new Stack<Func<Task>>();
         public async Task DoRollBack(Func<IContext, Task> logAction = null)
         {
-            while (RollBackActions != null && RollBackActions.Count > 0)
+            var rollbackErrors = new List<Exception>();
+            while (RollBackActions.Count > 0)
             {
                 var undoAction = RollBackActions.Pop();
                 try
@@ -26,25 +27,26 @@ namespace Looplex.OpenForExtension.Contexts
                 }
                 catch (Exception ex)
                 {
+                    rollbackErrors.Add(ex);
                     if (logAction != null)
                     {
-                        if (State != null)
-                        {
-                            State.Exception = ex;
-                            await logAction(this);
-                        }
+                        if ((object)State is IDictionary<string, object> stateBag)
+                            stateBag["Exception"] = ex;
+                       
+                        await logAction(this);
                     }
-                    throw;
                 }
             }
+            if (rollbackErrors.Count > 0)
+                throw new AggregateException("One or more rollback actions failed.", rollbackErrors);
         }
 
         public void AddRollBackAction(Func<Task> rollBackAction)
         {
-            if (rollBackAction != null)
-            {
-                RollBackActions.Push(rollBackAction);
-            }
+            if (rollBackAction == null)
+                throw new ArgumentNullException(nameof(rollBackAction));
+            
+            RollBackActions.Push(rollBackAction);
         }
         public static IContext New()
         {

--- a/src/Looplex.OpenForExtension/Contexts/DefaultContext.cs
+++ b/src/Looplex.OpenForExtension/Contexts/DefaultContext.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Threading.Tasks;
+using Looplex.OpenForExtension.Abstractions;
 using Looplex.OpenForExtension.Abstractions.Contexts;
 using Looplex.OpenForExtension.Abstractions.Plugins;
 
@@ -14,16 +15,25 @@ namespace Looplex.OpenForExtension.Contexts
         public IDictionary<string, dynamic> Roles { get; } = new Dictionary<string, dynamic>();
         public IList<IPlugin> Plugins { get; private set; }
         public object Result { get; set; }
-        public Stack<Func<Task>> RollBackActions { get; } = new Stack<Func<Task>>();
+        public Stack<NamedRollBack> RollBackActions { get; } = new Stack<NamedRollBack>();
         public async Task DoRollBack(Func<IContext, Task> logAction = null)
         {
             var rollbackErrors = new List<Exception>();
             while (RollBackActions.Count > 0)
             {
-                var undoAction = RollBackActions.Pop();
+                var undoNamedRb = RollBackActions.Pop();
                 try
                 {
-                    await undoAction();
+                    await undoNamedRb.Action();
+                    if(logAction != null)
+                    {
+                        if ((object)State is IDictionary<string, object> stateBag)
+                        {
+                            stateBag["LogMessage"] = undoNamedRb.Name;
+                        }
+
+                        await logAction(this);
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -31,7 +41,7 @@ namespace Looplex.OpenForExtension.Contexts
                     if (logAction != null)
                     {
                         if ((object)State is IDictionary<string, object> stateBag)
-                            stateBag["Exception"] = ex;
+                            stateBag["LogMessage"] = $"Error when trying to rollback plugin {undoNamedRb.Name} Exeption: {ex.Message}";
                        
                         await logAction(this);
                     }
@@ -41,12 +51,16 @@ namespace Looplex.OpenForExtension.Contexts
                 throw new AggregateException("One or more rollback actions failed.", rollbackErrors);
         }
 
-        public void AddRollBackAction(Func<Task> rollBackAction)
+        public void AddRollBackAction(Func<Task> rollBackAction, string name)
         {
             if (rollBackAction == null)
                 throw new ArgumentNullException(nameof(rollBackAction));
+
+            NamedRollBack rb = new NamedRollBack();
+            rb.Name = name;
+            rb.Action = rollBackAction;
             
-            RollBackActions.Push(rollBackAction);
+            RollBackActions.Push(rb);
         }
         public static IContext New()
         {

--- a/src/Looplex.OpenForExtension/Contexts/DefaultContext.cs
+++ b/src/Looplex.OpenForExtension/Contexts/DefaultContext.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Dynamic;
+using System.Threading.Tasks;
 using Looplex.OpenForExtension.Abstractions.Contexts;
 using Looplex.OpenForExtension.Abstractions.Plugins;
 
@@ -12,7 +14,34 @@ namespace Looplex.OpenForExtension.Contexts
         public IDictionary<string, dynamic> Roles { get; } = new Dictionary<string, dynamic>();
         public IList<IPlugin> Plugins { get; private set; }
         public object Result { get; set; }
+        public Stack<Func<Task>> RollBackActions { get; set; } = new Stack<Func<Task>>();
+        public async Task DoRollBack(Func<IContext, Task> logAction = null)
+        {
+            while (RollBackActions != null && RollBackActions.Count > 0)
+            {
+                var undoAction = RollBackActions.Pop();
+                try
+                {
+                    await undoAction();
+                }
+                catch (Exception ex)
+                {
+                    if (logAction != null)
+                    {
+                        if (State != null)
+                        {
+                            State.Exception = ex;
+                            await logAction(this);
+                        }
+                    }
+                }
+            }
+        }
 
+        public void AddRollBackAction(Func<Task> rollBackAction)
+        {
+            RollBackActions.Push(rollBackAction);
+        }
         public static IContext New()
         {
             return New(new List<IPlugin>());

--- a/src/Looplex.OpenForExtension/Contexts/DefaultContext.cs
+++ b/src/Looplex.OpenForExtension/Contexts/DefaultContext.cs
@@ -14,7 +14,7 @@ namespace Looplex.OpenForExtension.Contexts
         public IDictionary<string, dynamic> Roles { get; } = new Dictionary<string, dynamic>();
         public IList<IPlugin> Plugins { get; private set; }
         public object Result { get; set; }
-        public Stack<Func<Task>> RollBackActions { get; set; } = new Stack<Func<Task>>();
+        public Stack<Func<Task>> RollBackActions { get; } = new Stack<Func<Task>>();
         public async Task DoRollBack(Func<IContext, Task> logAction = null)
         {
             while (RollBackActions != null && RollBackActions.Count > 0)
@@ -34,13 +34,17 @@ namespace Looplex.OpenForExtension.Contexts
                             await logAction(this);
                         }
                     }
+                    throw;
                 }
             }
         }
 
         public void AddRollBackAction(Func<Task> rollBackAction)
         {
-            RollBackActions.Push(rollBackAction);
+            if (rollBackAction != null)
+            {
+                RollBackActions.Push(rollBackAction);
+            }
         }
         public static IContext New()
         {

--- a/src/Looplex.OpenForExtension/Plugins/AbstractPlugin.cs
+++ b/src/Looplex.OpenForExtension/Plugins/AbstractPlugin.cs
@@ -26,7 +26,7 @@ namespace Looplex.OpenForExtension.Plugins
             foreach (var command in Commands.Where(c => typeof(T).IsAssignableFrom(c.GetType())))
             {
                 await command.ExecuteAsync(context, cancellationToken);
-                context.AddRollBackAction(() => command.ExecuteRollBackAsync(context));
+                context.AddRollBackAction(() => command.ExecuteRollBackAsync(context), Name);
             }
         }
 

--- a/src/Looplex.OpenForExtension/Plugins/AbstractPlugin.cs
+++ b/src/Looplex.OpenForExtension/Plugins/AbstractPlugin.cs
@@ -26,6 +26,7 @@ namespace Looplex.OpenForExtension.Plugins
             foreach (var command in Commands.Where(c => typeof(T).IsAssignableFrom(c.GetType())))
             {
                 await command.ExecuteAsync(context, cancellationToken);
+                context.AddRollBackAction(() => command.ExecuteRollBackAsync(context));
             }
         }
 

--- a/test/BoyInTheAudiencePluginTests/BoyInTheAudiencePluginTests.csproj
+++ b/test/BoyInTheAudiencePluginTests/BoyInTheAudiencePluginTests.csproj
@@ -17,7 +17,6 @@
 	<PackageReference Include="MSTest.TestAdapter" Version="3.8.2" />
 	<PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
 	<PackageReference Include="NSubstitute" Version="5.3.0" />
-	<PackageReference Include="Looplex.OpenForExtension" Version="1.1.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Looplex.OpenForExtensionTests/Commands/TestCommand1.cs
+++ b/test/Looplex.OpenForExtensionTests/Commands/TestCommand1.cs
@@ -1,0 +1,25 @@
+﻿using Looplex.OpenForExtension.Abstractions.Contexts;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Looplex.OpenForExtensionTests.Commands
+{
+    public class TestCommand1 : ITestCommand1
+    {
+        public Task ExecuteAsync(IContext context, CancellationToken cancellationToken)
+        {
+            if(!((IDictionary<string, object>)context.State).ContainsKey("testString")) context.State.testString = string.Empty;
+            context.State.testString += "Executed 1 ";
+            return Task.CompletedTask;
+        }
+
+        public  Task ExecuteRollBackAsync(IContext context)
+        {
+            context.State.testString += "RollBack 1 ";
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/Looplex.OpenForExtensionTests/Commands/TestCommand2.cs
+++ b/test/Looplex.OpenForExtensionTests/Commands/TestCommand2.cs
@@ -1,0 +1,25 @@
+﻿using Looplex.OpenForExtension.Abstractions.Contexts;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Looplex.OpenForExtensionTests.Commands
+{
+    public class TestCommand2 : ITestCommand2
+    {
+        public Task ExecuteAsync(IContext context, CancellationToken cancellationToken)
+        {
+            if (!((IDictionary<string, object>)context.State).ContainsKey("testString")) context.State.testString = string.Empty;
+            context.State.testString += "Executed 2 ";
+            return Task.CompletedTask;
+        }
+
+        public Task ExecuteRollBackAsync(IContext context)
+        {
+            context.State.testString += "RollBack 2 ";
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/Looplex.OpenForExtensionTests/Commands/TestCommand3.cs
+++ b/test/Looplex.OpenForExtensionTests/Commands/TestCommand3.cs
@@ -1,0 +1,25 @@
+﻿using Looplex.OpenForExtension.Abstractions.Contexts;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Looplex.OpenForExtensionTests.Commands
+{
+    public class TestCommand3 : ITestCommand3
+    {
+        public Task ExecuteAsync(IContext context, CancellationToken cancellationToken)
+        {
+            if (!((IDictionary<string, object>)context.State).ContainsKey("testString")) context.State.testString = string.Empty;
+            context.State.testString += "Executed 3 ";
+            return Task.CompletedTask;
+        }
+
+        public Task ExecuteRollBackAsync(IContext context)
+        {
+            context.State.testString += "RollBack 3 ";
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/Looplex.OpenForExtensionTests/Commands/TestCommandFailRollback.cs
+++ b/test/Looplex.OpenForExtensionTests/Commands/TestCommandFailRollback.cs
@@ -1,0 +1,22 @@
+﻿using Looplex.OpenForExtension.Abstractions.Contexts;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Looplex.OpenForExtensionTests.Commands
+{
+    public class TestCommandFailRollback : ITestCommand3
+    {
+        public Task ExecuteAsync(IContext context, CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task ExecuteRollBackAsync(IContext context)
+        {
+            throw new Exception("Rollback failed");
+        }
+    }
+}

--- a/test/Looplex.OpenForExtensionTests/Contexts/DefaultContextTest.cs
+++ b/test/Looplex.OpenForExtensionTests/Contexts/DefaultContextTest.cs
@@ -1,0 +1,117 @@
+﻿using Looplex.OpenForExtension.Abstractions.Commands;
+using Looplex.OpenForExtension.Abstractions.Contexts;
+using Looplex.OpenForExtension.Abstractions.Plugins;
+using Looplex.OpenForExtension.Contexts;
+using Looplex.OpenForExtension.Plugins;
+using Looplex.OpenForExtensionTests.Commands;
+using NSubstitute;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Looplex.OpenForExtension.Abstractions.ExtensionMethods;
+using Looplex.OpenForExtensionTests.Plugins;
+
+namespace Looplex.OpenForExtensionTests.Contexts
+{
+    [TestClass]
+    public class DefaultContextTest
+    {
+        private DefaultContext? _context;
+
+        /// <summary>
+        /// checks if rollback is applied correctly in reverse order of called plugins
+        /// </summary>
+        /// <returns></returns>
+        [TestMethod]
+        public async Task DefaultContext_RollbackReverseOrder()
+        {
+            //Prepare
+            CancellationToken ct = CancellationToken.None;
+            string executed1 = "Executed 1 ";
+            string executed2 = "Executed 2 ";
+            string executed3 = "Executed 3 ";
+            string rollback1 = "RollBack 1 ";
+            string rollback2 = "RollBack 2 ";
+            string rollback3 = "RollBack 3 ";
+
+            IPlugin firstPlugin = new TestPlugin1();
+            IPlugin secondPlugin = new TestPlugin2();
+            IPlugin thirdPlugin = new TestPlugin3();
+
+            List<IPlugin> plugins = new List<IPlugin> { firstPlugin, secondPlugin, thirdPlugin };
+            _context = (DefaultContext)DefaultContext.New(plugins);
+
+            _context.State.testString = "";
+            await _context.Plugins.ExecuteAsync<ITestCommand1>(_context, ct);
+            await _context.Plugins.ExecuteAsync<ITestCommand2>(_context, ct);
+            await _context.Plugins.ExecuteAsync<ITestCommand3>(_context, ct);
+
+            await _context.DoRollBack();
+
+            Assert.AreEqual(_context.State.testString, executed1 + executed2 + executed3 + rollback3 + rollback2 + rollback1);
+
+        }
+        /// <summary>
+        /// Test simple log for plugin rollback and plugin rollback error
+        /// </summary>
+        /// <returns></returns>
+        [TestMethod]
+        public async Task DefaultContext_TestRollbackLogs()
+        {
+            //Prepare
+            CancellationToken ct = CancellationToken.None;
+
+            IPlugin firstPlugin = new TestPlugin1();
+            IPlugin secondPlugin = new TestPlugin2();
+            IPlugin thirdPlugin = new TestPlugin3RBFail();
+
+            List<IPlugin> plugins = new List<IPlugin> { firstPlugin, secondPlugin, thirdPlugin };
+            _context = (DefaultContext)DefaultContext.New(plugins);
+
+            await _context.Plugins.ExecuteAsync<ITestCommand1>(_context, ct);
+            await _context.Plugins.ExecuteAsync<ITestCommand2>(_context, ct);
+            await _context.Plugins.ExecuteAsync<ITestCommand3>(_context, ct);
+
+            string allRollbacksDone = "";
+            Func<IContext, Task> logAction = (IContext ctx) =>
+            {
+                string rbName = ctx.State.LogMessage;
+                allRollbacksDone += rbName;
+
+                return Task.CompletedTask;
+            };
+            try
+            {
+                await _context.DoRollBack(logAction);
+            }
+            catch
+            {
+            }
+
+            Assert.AreEqual(allRollbacksDone, $"Error when trying to rollback plugin {thirdPlugin.Name} Exeption: Rollback failed" + secondPlugin.Name + firstPlugin.Name);
+        }
+
+        /// <summary>
+        /// plugin rollback error must raise exception
+        /// </summary>
+        /// <returns></returns>
+        [TestMethod]
+        public async Task DefaultContext_TestRollbackErrorMustRaiseException()
+        {
+            //Prepare
+            CancellationToken ct = CancellationToken.None;
+
+            IPlugin thirdPlugin = new TestPlugin3RBFail();
+
+            List<IPlugin> plugins = new List<IPlugin> { thirdPlugin };
+            _context = (DefaultContext)DefaultContext.New(plugins);
+
+            await _context.Plugins.ExecuteAsync<ITestCommand3>(_context, ct);
+
+            Assert.ThrowsAsync<AggregateException>(async () => await _context.DoRollBack());
+        }
+    }
+}

--- a/test/Looplex.OpenForExtensionTests/Plugins/TestPlugin1.cs
+++ b/test/Looplex.OpenForExtensionTests/Plugins/TestPlugin1.cs
@@ -1,0 +1,27 @@
+﻿using Looplex.OpenForExtension.Abstractions.Commands;
+using Looplex.OpenForExtension.Plugins;
+using Looplex.OpenForExtensionTests.Commands;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Looplex.OpenForExtensionTests.Plugins
+{
+    public class TestPlugin1 : AbstractPlugin
+    {
+        public override string Name => "First test Plugin ";
+
+        public override string Description => "plugin for test 1";
+
+        public override IEnumerable<ICommand> Commands => [
+            new TestCommand1()
+        ];
+
+        public override IEnumerable<string> GetSubscriptions()
+        {
+            return [];
+        }
+    }
+}

--- a/test/Looplex.OpenForExtensionTests/Plugins/TestPlugin2.cs
+++ b/test/Looplex.OpenForExtensionTests/Plugins/TestPlugin2.cs
@@ -1,0 +1,27 @@
+﻿using Looplex.OpenForExtension.Abstractions.Commands;
+using Looplex.OpenForExtension.Plugins;
+using Looplex.OpenForExtensionTests.Commands;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Looplex.OpenForExtensionTests.Plugins
+{
+    internal class TestPlugin2 : AbstractPlugin
+    {
+        public override string Name => "second test Plugin ";
+
+        public override string Description => "plugin for test 2";
+
+        public override IEnumerable<ICommand> Commands => [
+            new TestCommand2()
+        ];
+
+        public override IEnumerable<string> GetSubscriptions()
+        {
+            return [];
+        }
+    }
+}

--- a/test/Looplex.OpenForExtensionTests/Plugins/TestPlugin3.cs
+++ b/test/Looplex.OpenForExtensionTests/Plugins/TestPlugin3.cs
@@ -1,0 +1,27 @@
+﻿using Looplex.OpenForExtension.Abstractions.Commands;
+using Looplex.OpenForExtension.Plugins;
+using Looplex.OpenForExtensionTests.Commands;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Looplex.OpenForExtensionTests.Plugins
+{
+    public class TestPlugin3 : AbstractPlugin
+    {
+        public override string Name => "Third test Plugin ";
+
+        public override string Description => "plugin for test 3";
+
+        public override IEnumerable<ICommand> Commands => [
+            new TestCommand3()
+        ];
+
+        public override IEnumerable<string> GetSubscriptions()
+        {
+            return [];
+        }
+    }
+}

--- a/test/Looplex.OpenForExtensionTests/Plugins/TestPlugin3RBFail.cs
+++ b/test/Looplex.OpenForExtensionTests/Plugins/TestPlugin3RBFail.cs
@@ -1,0 +1,27 @@
+﻿using Looplex.OpenForExtension.Abstractions.Commands;
+using Looplex.OpenForExtension.Plugins;
+using Looplex.OpenForExtensionTests.Commands;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Looplex.OpenForExtensionTests.Plugins
+{
+    public class TestPlugin3RBFail : AbstractPlugin
+    {
+        public override string Name => "Plugin whith rollbackfail";
+
+        public override string Description => "plugin for fail 3";
+
+        public override IEnumerable<ICommand> Commands => [
+            new TestCommandFailRollback()
+        ];
+
+        public override IEnumerable<string> GetSubscriptions()
+        {
+            return [];
+        }
+    }
+}

--- a/test/MutantNinjaTurtlePluginTests/MutantNinjaTurtlePluginTests.csproj
+++ b/test/MutantNinjaTurtlePluginTests/MutantNinjaTurtlePluginTests.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="MSTest.TestAdapter" Version="3.8.2" />
     <PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-	<PackageReference Include="Looplex.OpenForExtension" Version="1.1.8" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
with this a command must implement a rollback action, wich will be added to a stack of actions after plugin action is resolved,
if some exception is thrown application must call context rollback that applies the stacked rollback actions in reverse order
AB#33759

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rollback support added so executed commands can register asynchronous undo actions for later reversal.
  * Commands now expose an asynchronous rollback pathway; registered undo actions run in last-in, first-out order and aggregate/report failures.
  * Undo actions are automatically registered after successful command execution to enable reliable cleanup and state restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->